### PR TITLE
build(deps): bump framels to version 0.7.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "framels"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "framels"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2021"
 authors = ["Philippe Llerena<philippe.llerena@gmail.com>"]
 description = "a simple command line tool to list frame sequence in friendly way"

--- a/benches/mega.rs
+++ b/benches/mega.rs
@@ -2,9 +2,8 @@ use std::path::PathBuf;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use framels::{
-    basic_listing, parse_dir,
+    basic_listing, extended_listing, parse_dir,
     paths::{Paths, PathsPacked},
-    extended_listing,
 };
 
 fn generate_paths(n: u64) -> Paths {
@@ -31,7 +30,7 @@ fn small_parse_and_run() {
 fn exr_reading() {
     let source = "./samples/big/".to_string();
     let paths: Paths = parse_dir(&source);
-    let _results: PathsPacked = extended_listing(source,paths, false);
+    let _results: PathsPacked = extended_listing(source, paths, false);
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -7,9 +7,9 @@ title = "A simple but sexy ls command line tool"
 lead = '<b>framels</b> is a command line tool and lib dedicated to animation and vfx, for terminal user or simply other rust projects.'
 url = "/docs/getting-started/introduction/"
 url_button = "Get started"
-repo_version = "GitHub v0.7.6"
+repo_version = "GitHub v0.7.7"
 repo_license = "Open-source MIT License."
-repo_url = "https://github.com/forticheprod/fls/tree/0.7.6"
+repo_url = "https://github.com/forticheprod/fls/tree/0.7.7"
 
 # Menu items
 [[extra.menu.main]]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -42,7 +42,7 @@ fn cli_version() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("-V");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("framels 0.7.6"));
+        .stdout(predicate::str::contains("framels 0.7.7"));
 
     Ok(())
 }


### PR DESCRIPTION
Bump the version of framels from 0.7.6 to 0.7.7. This includes updates to the Cargo.lock and Cargo.toml files, as well as changes to the benches/mega.rs and docs/content/_index.md files. The updated version can be found on GitHub at [this link](https://github.com/forticheprod/fls/tree/0.7.7).